### PR TITLE
feat(XDMG): grids

### DIFF
--- a/data/book/book-xdmg.json
+++ b/data/book/book-xdmg.json
@@ -13947,6 +13947,9 @@
 											"width": 4934,
 											"height": 7000,
 											"id": "1f9",
+											"grid": {
+												"type": "none"
+											},
 											"mapRegions": [
 												{
 													"area": "320",
@@ -15165,6 +15168,9 @@
 											"credit": "Francesca Baerald",
 											"mapParent": {
 												"id": "1f9"
+											},
+											"grid": {
+												"type": "none"
 											}
 										}
 									]
@@ -15980,6 +15986,14 @@
 													"width": 2369,
 													"height": 3066,
 													"id": "1fb",
+													"grid": {
+														"type": "hexColsEven",
+														"size": 238,
+														"offsetX": -71,
+														"offsetY": -30,
+														"scale": 3,
+														"units": "miles"
+													},
 													"mapRegions": [
 														{
 															"area": "161",
@@ -16421,6 +16435,14 @@
 													"credit": "Mike Schley",
 													"mapParent": {
 														"id": "1fb"
+													},
+													"grid": {
+														"type": "hexColsEven",
+														"size": 238,
+														"offsetX": -71,
+														"offsetY": -30,
+														"scale": 3,
+														"units": "miles"
 													}
 												}
 											]
@@ -16573,10 +16595,18 @@
 												"path": "book/XDMG/078-map-5.03-flanaess.webp"
 											},
 											"imageType": "map",
+											"title": "Eastern Oerik",
 											"credit": "Mike Schley",
 											"width": 3040,
 											"height": 2136,
 											"id": "1fd",
+											"grid": {
+												"type": "hexColsEven",
+												"size": 311,
+												"scale": 15,
+												"distance": 30,
+												"units": "miles"
+											},
 											"mapRegions": [
 												{
 													"area": "364",
@@ -16699,7 +16729,14 @@
 											"title": "Player Version",
 											"width": 3040,
 											"height": 2136,
-											"id": "1fe"
+											"id": "1fe",
+											"grid": {
+												"type": "hexColsEven",
+												"size": 311,
+												"scale": 15,
+												"distance": 30,
+												"units": "miles"
+											}
 										}
 									]
 								},
@@ -27890,7 +27927,11 @@
 									"title": "Barrow Crypt",
 									"width": 5100,
 									"height": 6600,
-									"id": "1ff"
+									"id": "1ff",
+									"grid": {
+										"type": "square",
+										"size": 120
+									}
 								},
 								{
 									"type": "image",
@@ -27905,6 +27946,10 @@
 									"id": "201",
 									"mapParent": {
 										"id": "1ff"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120
 									}
 								}
 							]
@@ -27928,7 +27973,11 @@
 							"credit": "Dyson Logos",
 							"width": 5100,
 							"height": 6600,
-							"id": "202"
+							"id": "202",
+							"grid": {
+								"type": "square",
+								"size": 150
+							}
 						}
 					]
 				},
@@ -27949,7 +27998,14 @@
 							"credit": "Dyson Logos",
 							"width": 5100,
 							"height": 6600,
-							"id": "203"
+							"id": "203",
+							"grid": {
+								"type": "square",
+								"size": 120,
+								"offsetX": 5,
+								"offsetY": 5,
+								"distance": 25
+							}
 						}
 					]
 				},
@@ -27972,7 +28028,11 @@
 									"title": "Dragon's Lair",
 									"width": 5100,
 									"height": 6600,
-									"id": "204"
+									"id": "204",
+									"grid": {
+										"type": "square",
+										"size": 120
+									}
 								},
 								{
 									"type": "image",
@@ -27987,6 +28047,10 @@
 									"id": "205",
 									"mapParent": {
 										"id": "204"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120
 									}
 								}
 							]
@@ -28012,7 +28076,11 @@
 									"title": "Dungeon Hideout",
 									"width": 5100,
 									"height": 6600,
-									"id": "206"
+									"id": "206",
+									"grid": {
+										"type": "square",
+										"size": 120
+									}
 								},
 								{
 									"type": "image",
@@ -28027,6 +28095,10 @@
 									"id": "207",
 									"mapParent": {
 										"id": "206"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120
 									}
 								}
 							]
@@ -28050,7 +28122,11 @@
 							"credit": "Dyson Logos",
 							"width": 5100,
 							"height": 6600,
-							"id": "44b"
+							"id": "44b",
+							"grid": {
+								"type": "square",
+								"size": 120
+							}
 						}
 					]
 				},
@@ -28073,7 +28149,13 @@
 									"title": "Keep",
 									"width": 5100,
 									"height": 6600,
-									"id": "44c"
+									"id": "44c",
+									"grid": {
+										"type": "square",
+										"size": 356,
+										"offsetY": -113,
+										"scale": 3
+									}
 								},
 								{
 									"type": "image",
@@ -28088,6 +28170,12 @@
 									"id": "44d",
 									"mapParent": {
 										"id": "44c"
+									},
+									"grid": {
+										"type": "square",
+										"size": 356,
+										"offsetY": -113,
+										"scale": 3
 									}
 								}
 							]
@@ -28113,7 +28201,12 @@
 									"title": "Manor",
 									"width": 5100,
 									"height": 6600,
-									"id": "44e"
+									"id": "44e",
+									"grid": {
+										"type": "square",
+										"size": 356,
+										"scale": 3
+									}
 								},
 								{
 									"type": "image",
@@ -28128,6 +28221,11 @@
 									"id": "44f",
 									"mapParent": {
 										"id": "44e"
+									},
+									"grid": {
+										"type": "square",
+										"size": 356,
+										"scale": 3
 									}
 								}
 							]
@@ -28153,7 +28251,13 @@
 									"title": "Mine",
 									"width": 5100,
 									"height": 6600,
-									"id": "450"
+									"id": "450",
+									"grid": {
+										"type": "square",
+										"size": 356,
+										"offsetY": -140,
+										"scale": 3
+									}
 								},
 								{
 									"type": "image",
@@ -28168,6 +28272,12 @@
 									"id": "451",
 									"mapParent": {
 										"id": "450"
+									},
+									"grid": {
+										"type": "square",
+										"size": 356,
+										"offsetY": -140,
+										"scale": 3
 									}
 								}
 							]
@@ -28193,7 +28303,11 @@
 									"title": "Roadside Inn",
 									"width": 5100,
 									"height": 6600,
-									"id": "452"
+									"id": "452",
+									"grid": {
+										"type": "square",
+										"size": 120
+									}
 								},
 								{
 									"type": "image",
@@ -28208,6 +28322,10 @@
 									"id": "453",
 									"mapParent": {
 										"id": "452"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120
 									}
 								}
 							]
@@ -28233,7 +28351,13 @@
 									"title": "Ship",
 									"width": 5100,
 									"height": 6600,
-									"id": "454"
+									"id": "454",
+									"grid": {
+										"type": "square",
+										"size": 244,
+										"offsetX": -10,
+										"offsetY": 10
+									}
 								},
 								{
 									"type": "image",
@@ -28248,6 +28372,12 @@
 									"id": "455",
 									"mapParent": {
 										"id": "454"
+									},
+									"grid": {
+										"type": "square",
+										"size": 244,
+										"offsetX": -10,
+										"offsetY": 10
 									}
 								}
 							]
@@ -28273,7 +28403,11 @@
 									"title": "Spooky House",
 									"width": 5100,
 									"height": 6600,
-									"id": "456"
+									"id": "456",
+									"grid": {
+										"type": "square",
+										"size": 120
+									}
 								},
 								{
 									"type": "image",
@@ -28288,6 +28422,10 @@
 									"id": "457",
 									"mapParent": {
 										"id": "456"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120
 									}
 								}
 							]
@@ -28313,7 +28451,11 @@
 									"title": "Underdark Warren",
 									"width": 5100,
 									"height": 6600,
-									"id": "458"
+									"id": "458",
+									"grid": {
+										"type": "square",
+										"size": 120
+									}
 								},
 								{
 									"type": "image",
@@ -28328,6 +28470,10 @@
 									"id": "459",
 									"mapParent": {
 										"id": "458"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120
 									}
 								}
 							]
@@ -28353,7 +28499,12 @@
 									"title": "Volcanic Caves",
 									"width": 5100,
 									"height": 6600,
-									"id": "45a"
+									"id": "45a",
+									"grid": {
+										"type": "square",
+										"size": 364,
+										"scale": 3
+									}
 								},
 								{
 									"type": "image",
@@ -28368,6 +28519,11 @@
 									"id": "45b",
 									"mapParent": {
 										"id": "45a"
+									},
+									"grid": {
+										"type": "square",
+										"size": 364,
+										"scale": 3
 									}
 								}
 							]
@@ -28393,7 +28549,12 @@
 									"title": "Wizard's Tower",
 									"width": 5100,
 									"height": 6600,
-									"id": "45c"
+									"id": "45c",
+									"grid": {
+										"type": "square",
+										"size": 120,
+										"offsetX": 53
+									}
 								},
 								{
 									"type": "image",
@@ -28408,6 +28569,11 @@
 									"id": "45d",
 									"mapParent": {
 										"id": "45c"
+									},
+									"grid": {
+										"type": "square",
+										"size": 120,
+										"offsetX": 53
 									}
 								}
 							]


### PR DESCRIPTION
Also adds a `title` for `book/XDMG/078-map-5.03-flanaess.webp` based on the inset text on page 143 to ensure naming of both that map and it's 'Player-child-map' on import isn't rubbish. Could alternatively be titled `The Flanaess Region` based on text on page 160.