### PR TITLE
fix(list,filter-bestiary): guard against malformed brew data

### DIFF
--- a/js/filter-bestiary.js
+++ b/js/filter-bestiary.js
@@ -274,7 +274,13 @@ class PageFilterBestiary extends PageFilterBase {
 		this._mutateForFilters_speed(mon);
 		this._mutateForFilters_environment(mon);
 
-		mon._fAc = (mon.ac || []).map(it => it.special ? null : (it.ac || it)).filter(it => it !== null);
+		mon._fAc = (mon.ac || []).map(it => {
+			if (it == null || it.special) return null;
+			if (typeof it === "number") return it;
+			if (typeof it === "object") return typeof it.ac === "number" ? it.ac : null;
+			const m = String(it).match(/\d+/);
+			return m ? Number(m[0]) : null;
+		}).filter(it => it !== null);
 		if (!mon._fAc.length) mon._fAc = null;
 		mon._fHp = mon.hp?.average ?? null;
 		if (mon.alignment) {

--- a/js/list2.js
+++ b/js/list2.js
@@ -20,7 +20,7 @@ class ListHelpers {
 class ListItem {
 	static getCommonValues (ent) {
 		return {
-			group: ent.group ? ent.group.join(",") : "",
+			group: ent.group ? [ent.group].flat().join(",") : "",
 			alias: (ent.alias || []).map(it => `"${it}"`).join(","),
 			page: ent.page,
 		};


### PR DESCRIPTION
## Summary

Two small, independent defensive guards against malformed homebrew creature data. Both bugs share the same user-visible symptom: **a single bad entry makes the bestiary page silently fail to render** (empty list, console error or silent filter drop), with no UI affordance for the user to discover the cause.

### 1. `ListItem.getCommonValues` — non-array `group`

`list2.js:23` calls `ent.group.join(",")` unconditionally when `group` is truthy. If any entity has `group` as a string (schema violation — should be `string[]`), the `TypeError` propagates through `BestiaryPage._addData` → `pOnLoad`, and the **entire page renders empty** (no list, no stat block, no filters). Same code path is used by every list-based page.

Observed in several Elder Scrolls conversion brews (`MonstersOfMurkmire`, `EnemiesOfElsweyr`, etc.) — 142 monsters across four brews in one user's storage.

Console:
```
Uncaught (in promise) TypeError: ent.group.join is not a function
    at ListItem.getCommonValues (list2.js:23)
    at BestiaryPage.getListItem (bestiary.js:479)
    at BestiaryPage._addData (listpage.js:1352)
    at BestiaryPage.pOnLoad (listpage.js:1178)
```

**Fix:** `[ent.group].flat().join(",")`. Arrays pass through unchanged; a bare string becomes a single-element array. Schema unchanged.

### 2. `PageFilterBestiary.mutateForFilters` — non-object AC entries

`filter-bestiary.js:277` builds `mon._fAc` with `(mon.ac || []).map(it => it.special ? null : (it.ac || it))`. When `it` is a raw string (e.g. `"17* (natural armor)"`, produced by the homebrew converter's `AcConvert.tryPostProcessAc` fallback when the AC line fails to parse), `it.ac` is undefined and the string flows into `_fAc`. The Armor Class `RangeFilter` then silently drops it via `isNaN()` in `_addItem_addNumber` — no error, no UI signal, but the creature becomes **invisible in the bestiary list and search** until the Armor Class filter is manually reset.

**Fix:** normalize each entry to a numeric AC (or null): object with `.ac` → `.ac`; number → itself; string → leading integer via `/\d+/`; otherwise null.

## Scope / non-goals

- Both fixes are defensive only. The schema still requires `group: string[]` and `ac: [{ac, from}]`.
- Not touching the converter (`AcConvert.tryPostProcessAc`) — that's a separate concern and more invasive.
- Not attempting to guard every field in `mutateForFilters`. Other fields already use safe constructs (`Object.keys(truthy)`, `typeof === "number"`, optional chaining).

## Test plan

- [x] Bestiary loads with a homebrew containing `"group": "argonians"` (previously: blank page)
- [x] Bestiary loads with a homebrew containing `"ac": ["17* (natural armor)"]` and the creature appears in list/search (previously: invisible)
- [x] Correctly-formatted brews unchanged (`"group": ["..."]`, `"ac": [{"ac": 17, "from": [...]}]`)
- [x] Official data (MM / XMM Tyrannosaurus) unchanged — object-shape `ac` takes the same path; array-shape `group` unchanged
- [x] Creature with no `group` / no `ac` unchanged (returns `""` / `null` as before)