### PR TITLE
fix(render-markdown): correct double `.asText` in monster type/alignment

### DIFF
--- a/js/render-markdown.js
+++ b/js/render-markdown.js
@@ -1004,7 +1004,7 @@ class _RenderCompactMarkdownBestiaryImplBase {
 
 	_getCommonMdParts_sizeTypeAlignment ({mon, renderer, opts}) {
 		const monTypes = Parser.monTypeToFullObj(mon.type);
-		const sepTypeAlignment = monTypes.asText.asText.includes(",") ? "; " : ", ";
+		const sepTypeAlignment = monTypes.asText.includes(",") ? "; " : ", ";
 		return `>*${mon.level ? `${Parser.getOrdinalForm(mon.level)}-level ` : ""}${Renderer.utils.getRenderedSize(mon.size)} ${monTypes.asText}${mon.alignment ? `${sepTypeAlignment}${mon.alignmentPrefix ? RendererMarkdown.get().render(mon.alignmentPrefix) : ""}${Parser.alignmentListToFull(mon.alignment).toTitleCase()}` : ""}*`;
 	}
 

--- a/test/jest/RenderMarkdownMonsterTypeAlignment.test.js
+++ b/test/jest/RenderMarkdownMonsterTypeAlignment.test.js
@@ -1,0 +1,68 @@
+import "../../js/parser.js";
+import "../../js/utils.js";
+import "../../js/render.js";
+import "../../js/render-markdown.js";
+import "../../js/utils-config.js";
+
+/**
+ * `Parser.monTypeToFullObj` returns `asText` as a string, so the separator check in
+ * `_getCommonMdParts_sizeTypeAlignment` must read `asText`, not `asText.asText`.
+ *
+ * The separator is a semicolon where the rendered type text itself contains a comma
+ * -- e.g. "Celestial, Fey, or Fiend" -- so that the alignment stays legible.
+ *
+ * `_getCommonMdParts_sizeTypeAlignment` lives on the shared base class, so both the
+ * classic and one ("2024") bestiary renderers are covered.
+ */
+
+const getSizeTypeAlignmentLine = ({mon, styleHint}) => {
+	VetoolsConfig.set("styleSwitcher", "style", styleHint);
+	return RendererMarkdown.monster
+		.getCompactRenderedString(mon, {meta: {depth: 0, _typeStack: []}})
+		.split("\n")
+		.find(it => it.startsWith(">*"));
+};
+
+describe.each(["classic", "one"])("Markdown monster size/type/alignment (%s)", (styleHint) => {
+	it("Should separate a comma-free type from the alignment with a comma", () => {
+		expect(
+			getSizeTypeAlignmentLine({
+				styleHint,
+				mon: {
+					name: "Test Elemental",
+					size: ["M"],
+					type: "elemental",
+					alignment: ["N"],
+				},
+			}),
+		).toBe(">*Medium Elemental, Neutral*");
+	});
+
+	it("Should separate a type containing a comma from the alignment with a semicolon", () => {
+		expect(
+			getSizeTypeAlignmentLine({
+				styleHint,
+				mon: {
+					name: "Test Steed",
+					size: ["L"],
+					type: {type: {choose: ["celestial", "fey", "fiend"]}},
+					alignment: ["N"],
+				},
+			}),
+		).toBe(">*Large Celestial, Fey, or Fiend; Neutral*");
+	});
+
+	it("Should render a tagged type", () => {
+		expect(
+			getSizeTypeAlignmentLine({
+				styleHint,
+				mon: {
+					name: "Test Wizard",
+					size: ["M"],
+					type: {type: "undead", tags: ["wizard"]},
+					alignment: ["L", "E"],
+				},
+			}),
+		).toBe(">*Medium Undead (Wizard), Lawful Evil*");
+	});
+});


### PR DESCRIPTION
### The bug

`js/render-markdown.js:1007` reads `monTypes.asText.asText`:

```js
const monTypes = Parser.monTypeToFullObj(mon.type);
const sepTypeAlignment = monTypes.asText.asText.includes(",") ? "; " : ", ";
```

`Parser.monTypeToFullObj()` returns `asText` as a **string** (`js/parser.js:1826` — every branch assigns a string), so `monTypes.asText.asText` is always `undefined` and `.includes()` throws:

```
TypeError: Cannot read properties of undefined (reading 'includes')
    at _RenderCompactMarkdownBestiaryImplOne._getCommonMdParts_sizeTypeAlignment (js/render-markdown.js:1007:51)
    at _RenderCompactMarkdownBestiaryImplOne._getCommonMdParts (js/render-markdown.js:976:32)
    at _RenderCompactMarkdownBestiaryImplOne._getCompactRenderedString (js/render-markdown.js:1248:12)
```

### Scope

`_getCommonMdParts_sizeTypeAlignment` runs unconditionally for every monster, so this is not data-dependent — it throws on all of them. Rendering the whole bestiary (`includeLegacy: true`) to markdown:

| | rendered | failed |
|---|---|---|
| before | 0 | 4559 |
| after | 4559 | 0 |

Introduced in v2.35.0 (302acbe), which added the `sepTypeAlignment` line.

### The fix

One character group removed, matching the identical check the HTML renderer already spells correctly at `js/render.js:11083`:

```js
.join(typeObj.asText.includes(",") ? "; " : ", "),
```

### Verifying both branches

Comma in the type text takes `"; "`, otherwise `", "` — the behaviour the v2.35.0 change was after:

```
Otherworldly Steed     => >*Large Celestial, Fey, or Fiend; Neutral*
Aarakocra Aeromancer   => >*Medium Elemental, Neutral*
```